### PR TITLE
Replace concurrent hashmap with regular hashmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- [Java] Replace redundant concurrent hashmap with regular hashmap
 
 ## [13.5.0] - 2025-07-10
 ### Added

--- a/java/src/main/java/io/cucumber/query/Query.java
+++ b/java/src/main/java/io/cucumber/query/Query.java
@@ -35,20 +35,19 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
-import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.nullsFirst;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
@@ -74,19 +73,19 @@ public final class Query {
     private static final Map<TestStepResultStatus, Long> ZEROES_BY_TEST_STEP_RESULT_STATUSES = Arrays.stream(TestStepResultStatus.values())
             .collect(Collectors.toMap(identity(), (s) -> 0L));
     private final Comparator<TestStepResult> testStepResultComparator = nullsFirst(comparing(o -> o.getStatus().ordinal()));
-    private final Map<String, TestCaseStarted> testCaseStartedById = new ConcurrentHashMap<>();
-    private final Map<String, TestCaseFinished> testCaseFinishedByTestCaseStartedId = new ConcurrentHashMap<>();
-    private final Map<String, List<TestStepFinished>> testStepsFinishedByTestCaseStartedId = new ConcurrentHashMap<>();
-    private final Map<String, List<TestStepStarted>> testStepsStartedByTestCaseStartedId = new ConcurrentHashMap<>();
-    private final Map<String, Pickle> pickleById = new ConcurrentHashMap<>();
-    private final Map<String, TestCase> testCaseById = new ConcurrentHashMap<>();
-    private final Map<String, Step> stepById = new ConcurrentHashMap<>();
-    private final Map<String, TestStep> testStepById = new ConcurrentHashMap<>();
-    private final Map<String, PickleStep> pickleStepById = new ConcurrentHashMap<>();
-    private final Map<String, Hook> hookById = new ConcurrentHashMap<>();
-    private final Map<String, List<Attachment>> attachmentsByTestCaseStartedId = new ConcurrentHashMap<>();
-    private final Map<Object, Lineage> lineageById = new ConcurrentHashMap<>();
-    private final Map<String, StepDefinition> stepDefinitionById = new ConcurrentHashMap<>();
+    private final Map<String, TestCaseStarted> testCaseStartedById = new LinkedHashMap<>();
+    private final Map<String, TestCaseFinished> testCaseFinishedByTestCaseStartedId = new HashMap<>();
+    private final Map<String, List<TestStepFinished>> testStepsFinishedByTestCaseStartedId = new HashMap<>();
+    private final Map<String, List<TestStepStarted>> testStepsStartedByTestCaseStartedId = new HashMap<>();
+    private final Map<String, Pickle> pickleById = new LinkedHashMap<>();
+    private final Map<String, TestCase> testCaseById = new HashMap<>();
+    private final Map<String, Step> stepById = new HashMap<>();
+    private final Map<String, TestStep> testStepById = new LinkedHashMap<>();
+    private final Map<String, PickleStep> pickleStepById = new LinkedHashMap<>();
+    private final Map<String, Hook> hookById = new LinkedHashMap<>();
+    private final Map<String, List<Attachment>> attachmentsByTestCaseStartedId = new HashMap<>();
+    private final Map<Object, Lineage> lineageById = new HashMap<>();
+    private final Map<String, StepDefinition> stepDefinitionById = new HashMap<>();
     private Meta meta;
     private TestRunStarted testRunStarted;
     private TestRunFinished testRunFinished;
@@ -107,22 +106,15 @@ public final class Query {
     }
 
     public List<Pickle> findAllPickles() {
-        return pickleById.values().stream()
-                .sorted(comparing(Pickle::getId))
-                .collect(toList());
+        return new ArrayList<>(pickleById.values());
     }
 
     public List<PickleStep> findAllPickleSteps() {
-        return pickleStepById.values().stream()
-                .sorted(comparing(PickleStep::getId))
-                .collect(toList());
+        return new ArrayList<>(pickleStepById.values());
     }
 
     public List<TestCaseStarted> findAllTestCaseStarted() {
         return this.testCaseStartedById.values().stream()
-                .sorted(comparing(TestCaseStarted::getTimestamp, new TimestampComparator())
-                        // tie-breaker for stability
-                        .thenComparing(TestCaseStarted::getId))
                 .filter(element -> !findTestCaseFinishedBy(element)
                         .filter(TestCaseFinished::getWillBeRetried)
                         .isPresent())
@@ -136,15 +128,8 @@ public final class Query {
                     Optional<Lineage> astNodes = findLineageBy(testCaseStarted);
                     return new SimpleEntry<>(astNodes, testCaseStarted);
                 })
-                // Sort entries by gherkin document URI for consistent ordering
-                .sorted(comparing(
-                        entry -> entry.getKey()
-                                .flatMap(nodes -> nodes.document().getUri())
-                                .orElse(null),
-                        nullsFirst(naturalOrder())
-                ))
                 .map(entry -> {
-                    // Unpack the now sorted entries
+                    // Unpack the now grouped entries
                     Optional<Feature> feature = entry.getKey().flatMap(Lineage::feature);
                     TestCaseStarted testcaseStarted = entry.getValue();
                     return new SimpleEntry<>(feature, testcaseStarted);
@@ -156,9 +141,7 @@ public final class Query {
     }
 
     public List<TestStep> findAllTestSteps() {
-        return testStepById.values().stream()
-                .sorted(comparing(TestStep::getId))
-                .collect(toList());
+        return new ArrayList<>(testStepById.values());
     }
 
     public List<Attachment> findAttachmentsBy(TestStepFinished testStepFinished) {

--- a/javascript/src/Query.ts
+++ b/javascript/src/Query.ts
@@ -428,13 +428,11 @@ export default class Query {
   }
 
   public findAllPickles(): ReadonlyArray<Pickle> {
-    const pickles = [...this.pickleById.values()]
-    return sortBy(pickles, ['id'])
+    return [...this.pickleById.values()]
   }
 
   public findAllPickleSteps(): ReadonlyArray<PickleStep> {
-    const pickleSteps = [...this.pickleStepById.values()]
-    return sortBy(pickleSteps, ['id'])
+    return [...this.pickleStepById.values()]
   }
 
   public findAllTestCaseStarted(): ReadonlyArray<TestCaseStarted> {
@@ -469,8 +467,7 @@ export default class Query {
   }
 
   public findAllTestSteps(): ReadonlyArray<TestStep> {
-    const testSteps = [...this.testStepById.values()]
-    return sortBy(testSteps, ['id'])
+    return [...this.testStepById.values()]
   }
 
   public findAttachmentsBy(testStepFinished: TestStepFinished): ReadonlyArray<Attachment> {

--- a/testdata/examples-tables.feature.query-results.json
+++ b/testdata/examples-tables.feature.query-results.json
@@ -159,10 +159,6 @@
     "Eating cucumbers with 0 friends"
   ],
   "findPickleStepBy" : [
-    "each person can eat 2 cucumbers",
-    "there are 0 friends",
-    "there are 4 cucumbers",
-    "each person can eat 4 cucumbers",
     "there are 12 cucumbers",
     "I eat 5 cucumbers",
     "I should have 7 cucumbers",
@@ -185,7 +181,11 @@
     "there are 12 cucumbers",
     "each person can eat 1 cucumbers",
     "there are 1 friends",
-    "there are 4 cucumbers"
+    "there are 4 cucumbers",
+    "each person can eat 2 cucumbers",
+    "there are 0 friends",
+    "there are 4 cucumbers",
+    "each person can eat 4 cucumbers"
   ],
   "findStepBy" : [
     "there are <start> cucumbers",
@@ -218,18 +218,6 @@
   ],
   "findStepDefinitionsBy" : [
     [
-      "4"
-    ],
-    [
-      "1"
-    ],
-    [
-      "0"
-    ],
-    [
-      "4"
-    ],
-    [
       "0"
     ],
     [
@@ -293,13 +281,21 @@
     ],
     [
       "0"
+    ],
+    [
+      "4"
+    ],
+    [
+      "1"
+    ],
+    [
+      "0"
+    ],
+    [
+      "4"
     ]
   ],
   "findUnambiguousStepDefinitionBy" : [
-    "4",
-    "1",
-    "0",
-    "4",
     "0",
     "2",
     "3",
@@ -320,7 +316,11 @@
     "0",
     "4",
     "1",
-    "0"
+    "0",
+    "4",
+    "1",
+    "0",
+    "4"
   ],
   "findTestCaseBy" : [
     "73",


### PR DESCRIPTION
### 🤔 What's changed?

While the query object can be updated by multiple scenarios running concurrently, in practice these updates are sequenced to only allow a single update at once. Additionally we can now rely on insertion order rather than sorting.

### ⚡️ What's your motivation? 

Improve performance.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
