### PR TITLE
Use Trusted Publishing for NuGet

### DIFF
--- a/.github/workflows/release-nuget.yaml
+++ b/.github/workflows/release-nuget.yaml
@@ -19,7 +19,12 @@ jobs:
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: 10.0.x
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - uses: cucumber/action-publish-nuget@f059d15b2dbcd962afc0d29424f4f083177255aa # v1.0.0
         with:
-          nuget-api-key: ${{ secrets.NUGET_API_KEY }}
+          nuget-api-key: ${{ steps.login.outputs.NUGET_API_KEY }}
           working-directory: "dotnet"


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Work towards https://github.com/cucumber/common/issues/2282.

### 🏷️ What kind of change is this?
- :book: Documentation (improvements without changing code)

### 📋 Checklist:

- [x] Remove `NUGET_API_KEY` from secrets
- [x] Add `NUGET_USER` to secrets
- [x] Configure trusted publisher in NuGet
- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
