### PR TITLE
Prefer Pickle.Location with fallback to Lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Prefer Pickle.Location with fallback to Lineage ([#175](https://github.com/cucumber/query/pull/175))
 
 ## [16.0.0] - 2026-06-11
 ### Changed

--- a/dotnet/Cucumber.Query/Query.cs
+++ b/dotnet/Cucumber.Query/Query.cs
@@ -155,6 +155,8 @@ public class Query
 
     public Location? FindLocationOf(Pickle pickle)
     {
+        if (pickle.Location != null)
+            return pickle.Location;
         var lineage = FindLineageBy(pickle);
         if (lineage == null)
             return null;

--- a/dotnet/Cucumber.QueryTest/QueryTest.cs
+++ b/dotnet/Cucumber.QueryTest/QueryTest.cs
@@ -1,5 +1,6 @@
 using Io.Cucumber.Messages.Types;
 using Cucumber.Query;
+using System.Text;
 
 namespace Cucumber.QueryTest;
 
@@ -46,6 +47,50 @@ public class QueryTest
         Assert.AreEqual(1, result.Count());
         Assert.AreEqual(c, result.ToArray()[0]);
         Assert.AreEqual(1, _query.TestCasesStartedCount);
+    }
+
+    [TestMethod]
+    public void FindLocationOfFallsBackToScenarioLocationWhenPickleHasNoLocation()
+    {
+        var envelopes = LoadEnvelopes("minimal.ndjson");
+        var query = BuildQuery(envelopes);
+        var pickle = FindPickle(envelopes);
+
+        Assert.AreEqual(pickle.Location, query.FindLocationOf(StripLocation(pickle)));
+    }
+
+    [TestMethod]
+    public void FindLocationOfFallsBackToExampleRowLocationWhenPickleHasNoLocation()
+    {
+        var envelopes = LoadEnvelopes("examples-tables.ndjson");
+        var query = BuildQuery(envelopes);
+        var pickle = FindPickle(envelopes);
+
+        Assert.AreEqual(pickle.Location, query.FindLocationOf(StripLocation(pickle)));
+    }
+
+    private static Cucumber.Query.Query BuildQuery(IEnumerable<Envelope> envelopes)
+    {
+        var repository = Repository.CreateWithAllFeatures();
+        foreach (var envelope in envelopes)
+            repository.Update(envelope);
+        return new Cucumber.Query.Query(repository);
+    }
+
+    private static Pickle FindPickle(IEnumerable<Envelope> envelopes) =>
+        envelopes.First(e => e.Pickle != null).Pickle;
+
+    private static Pickle StripLocation(Pickle pickle) =>
+        new Pickle(pickle.Id, pickle.Uri, null, pickle.Name, pickle.Language, pickle.Steps,
+            pickle.Tags, pickle.AstNodeIds);
+
+    private static IReadOnlyList<Envelope> LoadEnvelopes(string source)
+    {
+        var path = Path.Combine(TestFolderHelper.TestFolder, "src", source);
+        return File.ReadAllLines(path, Encoding.UTF8)
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .Select(NdjsonSerializer.Deserialize)
+            .ToList();
     }
 
     private static string RandomId() => Guid.NewGuid().ToString();

--- a/javascript/src/Query.spec.ts
+++ b/javascript/src/Query.spec.ts
@@ -90,14 +90,7 @@ describe('Query', () => {
 
   describe('#findLineageBy', () => {
     it('returns correct lineage for a minimal scenario', async () => {
-      const envelopes: ReadonlyArray<Envelope> = (
-        await fs.readFile(path.join(import.meta.dirname, '../../testdata/src/minimal.ndjson'), {
-          encoding: 'utf-8',
-        })
-      )
-        .split('\n')
-        .filter((line) => !!line)
-        .map((line) => JSON.parse(line))
+      const envelopes = await loadEnvelopes('minimal.ndjson')
       for (const envelope of envelopes) {
         cucumberQuery.update(envelope)
       }
@@ -115,17 +108,7 @@ describe('Query', () => {
     })
 
     it('returns correct lineage for a pickle from an examples table', async () => {
-      const envelopes: ReadonlyArray<Envelope> = (
-        await fs.readFile(
-          path.join(import.meta.dirname, '../../testdata/src/examples-tables.ndjson'),
-          {
-            encoding: 'utf-8',
-          }
-        )
-      )
-        .split('\n')
-        .filter((line) => !!line)
-        .map((line) => JSON.parse(line))
+      const envelopes = await loadEnvelopes('examples-tables.ndjson')
       for (const envelope of envelopes) {
         cucumberQuery.update(envelope)
       }
@@ -149,17 +132,7 @@ describe('Query', () => {
     })
 
     it('returns correct lineage for a pickle with background-derived steps', async () => {
-      const envelopes: ReadonlyArray<Envelope> = (
-        await fs.readFile(
-          path.join(import.meta.dirname, '../../testdata/src/rules-backgrounds.ndjson'),
-          {
-            encoding: 'utf-8',
-          }
-        )
-      )
-        .split('\n')
-        .filter((line) => !!line)
-        .map((line) => JSON.parse(line))
+      const envelopes = await loadEnvelopes('rules-backgrounds.ndjson')
       for (const envelope of envelopes) {
         cucumberQuery.update(envelope)
       }
@@ -184,4 +157,43 @@ describe('Query', () => {
       } satisfies Lineage)
     })
   })
+
+  describe('#findLocationOf', () => {
+    it('falls back to the scenario location when the pickle has no location', async () => {
+      const envelopes = await loadEnvelopes('minimal.ndjson')
+      for (const envelope of envelopes) {
+        cucumberQuery.update(envelope)
+      }
+      const pickle = envelopes.find((envelope) => envelope.pickle).pickle
+
+      assert.deepStrictEqual(
+        cucumberQuery.findLocationOf({ ...pickle, location: undefined }),
+        pickle.location
+      )
+    })
+
+    it('falls back to the example row location when the pickle has no location', async () => {
+      const envelopes = await loadEnvelopes('examples-tables.ndjson')
+      for (const envelope of envelopes) {
+        cucumberQuery.update(envelope)
+      }
+      const pickle = envelopes.find((envelope) => envelope.pickle).pickle
+
+      assert.deepStrictEqual(
+        cucumberQuery.findLocationOf({ ...pickle, location: undefined }),
+        pickle.location
+      )
+    })
+  })
 })
+
+async function loadEnvelopes(filename: string): Promise<ReadonlyArray<Envelope>> {
+  return (
+    await fs.readFile(path.join(import.meta.dirname, '../../testdata/src', filename), {
+      encoding: 'utf-8',
+    })
+  )
+    .split('\n')
+    .filter((line) => !!line)
+    .map((line) => JSON.parse(line))
+}

--- a/javascript/src/Query.ts
+++ b/javascript/src/Query.ts
@@ -443,6 +443,9 @@ export default class Query {
   }
 
   public findLocationOf(pickle: Pickle): Location | undefined {
+    if (pickle.location) {
+      return pickle.location
+    }
     const lineage = this.findLineageBy(pickle)
     if (lineage?.example) {
       return lineage.example.location


### PR DESCRIPTION
### 🤔 What's changed?

Pickle.Location is present in newer versions of Cucumber, so if it's there we should use it rather than go through the Lineage to get it. We should still maintain the fallback though, since Query will be used for formatters that might still be dealing with messages from older versions.

(This brings the .NET and JavaScript versions in line with what Java was already doing.)

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*